### PR TITLE
Use more bytes of seed for gmp_randseed, do not use gmp_randseed_ui because it is always only 32-bits of entropy

### DIFF
--- a/etlp.c
+++ b/etlp.c
@@ -9,6 +9,7 @@
 #define DEF_TESTIME 1 /* seconds */
 #define SQUARES_PER_CICLE 1000UL /* squares to do each cicle */
 #define PRIME_LEN 512 /* prime bit length */
+#define ENTROPY_BYTES (PRIME_LEN/2) /* amount of bytes to read from /dev/urandom */
 #define BASE16 16
 #define BASE10 10
 
@@ -40,14 +41,18 @@ setup(void)
 
 	/* Setup gmp random generator */
 	FILE *fp;
-	unsigned long int random_seed;
+	unsigned char random_bytes[ENTROPY_BYTES];
 
 	fp = fopen("/dev/urandom", "r");
-	fscanf(fp, "%lu", &random_seed);
+	fread(random_bytes, sizeof(unsigned char), ENTROPY_BYTES, fp);
 	fclose(fp);
 
+	mpz_t random_seed;
+	mpz_init(random_seed);
+	mpz_import(random_seed, ENTROPY_BYTES, 1, sizeof(unsigned char), 0, 0, random_bytes);
+
 	gmp_randinit_default(random_gen);
-	gmp_randseed_ui(random_gen, random_seed);
+	gmp_randseed(random_gen, random_seed);
 }
 
 /* Obtain the modulus n and fi(n) by creating two big random primes values


### PR DESCRIPTION
hello!

gmp_randseed_ui takes a 32-bit random number. This means the entropy of the generated modulus/base will be at most 32-bits. An attacker could iterate through all of these seed values in parallel to find the primes that produce a modulus generated by etlp. This takes some time (about three days on 8 cores, according to some experiments I did), but its possible an attacker could create a table of every modulus/base generated by every seed, together with the prime factors, so lookups would be faster

`ENTROPY_BYTES = (PRIME_LEN/2)` because gen_modulos and gen_gen_base together query the random number generator for `PRIME_LEN*4` bits. Because ENTROPY_BYTES is in bytes and PRIME_LEN is in bits, we divide by 8 to get `PRIME_LEN*4/8` = `PRIME_LEN/2`